### PR TITLE
feat: add react/jsx-wrap-multilines

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,13 @@ module.exports = {
             },
         ],
         'react/jsx-props-no-spreading': 0,
+        'react/jsx-wrap-multilines': ['error', {
+            'declaration': 'parens-new-line',
+            'assignment': 'parens-new-line',
+            'return': 'parens-new-line',
+            'arrow': 'parens-new-line',
+            'logical': 'parens'
+        }],
         'react/prop-types': 0,
         'import/no-import-module-exports': 2,
         'import/no-commonjs': 2,


### PR DESCRIPTION
Following @eran7789 's comment on this PR https://github.com/Houzz/ivy-documents/pull/4791#discussion_r1837674926 .

Wrapping multi-line jsx fragments with parenthesis is good practice. 

Example:

🚫 Bad
```
function Hello() {
   // Missing parens
   const content = <div>
      foo
      bar
   </div>;

   // Missing parens
    return <div>
      <p>{content}</p>
    </div>;
}
```

✅  Good

```
function Hello() {
   const content = (
     <div>
       foo
       bar
     </div>
  );

  return (
    <div>
      <p>{content}</p>
    </div>
  );
}
```