### PR TITLE
feat: remove `arrow-parens`

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ module.exports = {
         'import/extensions': 0,
         'import/prefer-default-export': 0,
         'import/named': 0,
-        'arrow-parens': 0,
         'global-require': 0,
         'import/no-dynamic-require': 0,
         'jsx-a11y/click-events-have-key-events': 0,


### PR DESCRIPTION
### Summary

Remove [arrow-parens](https://eslint.org/docs/latest/rules/arrow-parens) because

1. Always provide the parentheses, making it easier to add/remove parameters
2. It's the default value (i.e., recommended value) of ESlint and Prettier
3. This rule was deprecated in ESLint v8.53.0, so removing it now
